### PR TITLE
Introduced "bdroid_buildcfg.h" based on device type   to enable BTA_AV_SINK_INCLUDED for IVI only

### DIFF
--- a/bluetooth/intel/car/bdroid_buildcfg.h
+++ b/bluetooth/intel/car/bdroid_buildcfg.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _BDROID_BUILDCFG_H
+#define _BDROID_BUILDCFG_H
+
+#define BTM_DEF_LOCAL_NAME "gmin-bluetooth"
+// Bluetooth Low Power Mode is supported on BT4.0
+#define HCILP_INCLUDED                 FALSE
+
+#define BTA_AV_SINK_INCLUDED TRUE
+
+/* Default class of device
+* {SERVICE_CLASS, MAJOR_CLASS, MINOR_CLASS}
+*
+* SERVICE_CLASS:0x1A (Bit17 -Networking,Bit19 - Capturing,Bit20 -Object Transfer)
+* MAJOR_CLASS:0x01 - COMPUTER
+* MINOR_CLASS:0x1C - TABLET
+*/
+
+
+#define BTA_DM_COD {0x1A, 0x01, 0x1C}
+
+#define PRELOAD_MAX_RETRY_ATTEMPTS 1
+
+#define PRELOAD_START_TIMEOUT_MS 3500
+
+#define BLE_VND_INCLUDED TRUE
+
+#endif

--- a/bluetooth/intel/tablet/bdroid_buildcfg.h
+++ b/bluetooth/intel/tablet/bdroid_buildcfg.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _BDROID_BUILDCFG_H
+#define _BDROID_BUILDCFG_H
+
+#define BTM_DEF_LOCAL_NAME "gmin-bluetooth"
+// Bluetooth Low Power Mode is supported on BT4.0
+#define HCILP_INCLUDED                 FALSE
+
+/* Default class of device
+* {SERVICE_CLASS, MAJOR_CLASS, MINOR_CLASS}
+*
+* SERVICE_CLASS:0x1A (Bit17 -Networking,Bit19 - Capturing,Bit20 -Object Transfer)
+* MAJOR_CLASS:0x01 - COMPUTER
+* MINOR_CLASS:0x1C - TABLET
+*/
+
+
+#define BTA_DM_COD {0x1A, 0x01, 0x1C}
+
+#define PRELOAD_MAX_RETRY_ATTEMPTS 1
+
+#define PRELOAD_START_TIMEOUT_MS 3500
+
+#define BLE_VND_INCLUDED TRUE
+
+#endif


### PR DESCRIPTION
Description:
- To make IVI work as Audio Sink device, need to enable
  flag "BTA_AV_SINK_INCLUDED" in system/bt.
- Since this flag should be enabled only for IVI,
  created seperate header file for both IVI and tablet.

Jira: https://jira01.devtools.intel.com/browse/OAM-65576

Test:
- BT AVRCP should work, user shouble be able to control music
  from Bluetooth Audio App on kabylake IVI - PASS

Signed-off-by: Umesh Agarwal <umeshx.agarwal@intel.com>