### PR TITLE
Disable sniff sub-rating causing timeout issue During SST testing

### DIFF
--- a/bluetooth/intel/car/bdroid_buildcfg.h
+++ b/bluetooth/intel/car/bdroid_buildcfg.h
@@ -40,4 +40,6 @@
 
 #define BLE_VND_INCLUDED TRUE
 
+#define BTM_SSR_INCLUDED FALSE
+
 #endif


### PR DESCRIPTION
issue :
- Pixel phone getting disconnected, after MAP operations are performed

fix:
- As the sniff sub-rating is optional, disable it.

Jira: https://jira01.devtools.intel.com/browse/OAM-65440
Test: 
1) connect Pixel phone
2) Perform MAP operations
Expected behavior  -> Pixel phone should stay connected
Actual Behavior -> Pixel phone is connected.
Signed-off-by: anitha3x <anithax.h.chandrasekar@intel.com>