### PR TITLE
Added configuration files for celadon TABLET

### DIFF
--- a/bluetooth/overlay-tablet/packages/apps/Bluetooth/res/values/config.xml
+++ b/bluetooth/overlay-tablet/packages/apps/Bluetooth/res/values/config.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2009-2012 Broadcom Corporation
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<resources>
+    <bool name="enable_phone_policy">true</bool>
+    <bool name="profile_supported_a2dp">false</bool>
+    <bool name="profile_supported_hdp">true</bool>
+    <bool name="profile_supported_hs_hfp">true</bool>
+    <bool name="profile_supported_hid_host">true</bool>
+    <bool name="profile_supported_opp">true</bool>
+    <bool name="profile_supported_pan">true</bool>
+    <bool name="profile_supported_pbap">true</bool>
+    <bool name="profile_supported_gatt">true</bool>
+    <bool name="pbap_include_photos_in_vcard">true</bool>
+    <bool name="pbap_use_profile_for_owner_vcard">true</bool>
+    <bool name="profile_supported_map">true</bool>
+    <bool name="profile_supported_avrcp_target">false</bool>
+    <bool name="profile_supported_hid_device">true</bool>
+</resources>


### PR DESCRIPTION
Description:
- Addition of configuration files 'overlay-tablet' to
  enable all the profiles relevant to TABLET, except A2DP
  and AVRCP.
- Disabled A2DP, AVRCP, since we do not support
  New AVRCP for Android P

Tracked-On: OAM-67866

Signed-off-by: anitha3x <anithax.h.chandrasekar@intel.com>