### PR TITLE
Enable support for HID  devices in overlay-car packages

### DIFF
--- a/bluetooth/overlay-car/packages/apps/Bluetooth/res/values/config.xml
+++ b/bluetooth/overlay-car/packages/apps/Bluetooth/res/values/config.xml
@@ -20,8 +20,8 @@
     <bool name="profile_supported_avrcp_controller">true</bool>
     <bool name="profile_supported_pbapclient">true</bool>
     <bool name="profile_supported_opp">true</bool>
-    <bool name="profile_supported_hid">true</bool>
+    <bool name="profile_supported_hid_host">true</bool>
     <bool name="profile_supported_mapmce">true</bool>
     <!-- For enabling the hfp client connection service -->
-    <bool name="hfp_client_connection_service_enabled">true</bool>
+    <bool name="hfp_client_connection_service_enabled">false</bool>
 </resources>


### PR DESCRIPTION
Description:
At the time of reboot, reference phone didn't
reconnect automatically.To overcome this issue
we have set hfp_client TRUE,so that at the time
of auto-connect,Car service will intiate connect
for bt profiles

Tracked-On: OAM-70153

Signed-off-by: umeshagx <umeshx.agarwal@intel.com>