### PR TITLE
Fix cts failure in CtsAppTestCases

### DIFF
--- a/framework/android.software.cant_save_state.xml
+++ b/framework/android.software.cant_save_state.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<permissions>
+    <feature name="android.software.cant_save_state" />
+</permissions>


### PR DESCRIPTION
CTS failure due to don't support feature: FEATURE_CANT_SAVE_STATE
the feature is for supporting the R.attr.cantSaveState API( sdk28),
the cantSaveState declare that this application can't participate
in the normal state save/restore mechanism.

Test: run cts -m CtsAppTestCases
-t android.app.cts.ActivityManagerProcessStateTest#testCantSaveStateLaunchAndBackground
run cts -m CtsAppTestCases
-t android.app.cts.ActivityManagerProcessStateTest#testCantSaveStateLaunchAndSwitch

Tracked-On: OAM-71298
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>