### PR TITLE
[PORT FROM OMR1] Clean critical KW issue in BOOT-OTA domain

### DIFF
--- a/set_storage/set_storage.c
+++ b/set_storage/set_storage.c
@@ -59,11 +59,12 @@ int main(__attribute__((unused)) int argc, __attribute__((unused)) char **argv)
 	}
 
 	ret = symlink(path, link_device);
-	free(path);
 	if (ret) {
 		ALOGE("Failed to symlink storage device %s\n", path);
+		free(path);
 		return EXIT_FAILURE;
 	}
+	free(path);
 
 	passwd = getpwnam("system");
 	if (!passwd) {


### PR DESCRIPTION
1): Initialized 'file_path' array when used in this function.
2): Fix overflow buffer and unvalidated string dereference.
3): Fix object 'path' was used after being freed by calling 'free'.

Change-Id: Id817468f43fd3d7a1eb820b27bd66390b8ea89c2
Tracked-On: OAM-72792
Signed-off-by: sunxunou <xunoux.sun@intel.com>
Signed-off-by: phireg <philippe.regnier@intel.com>