### PR TITLE
set_storage: enable first stage mount support.

### DIFF
--- a/set_storage/Android.mk
+++ b/set_storage/Android.mk
@@ -16,3 +16,19 @@ LOCAL_STATIC_LIBRARIES := \
 	liblog
 
 include $(BUILD_EXECUTABLE)
+
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := set_storage.vendor
+LOCAL_SRC_FILES := set_storage.c
+LOCAL_CFLAGS := -Wall -Wextra -Werror
+
+LOCAL_PROPRIETARY_MODULE := true
+
+LOCAL_SHARED_LIBRARIES := \
+	libcutils \
+	libc \
+	liblog
+
+include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
After enable treble/first stage mount support, need put the set_storage
to vendor/bin/

Tracked-on: OAM-71435
Signed-off-by: Ming Tan <ming.tan@intel.com>