### PR TITLE
Enable AppWidgetService even the feature is disable

### DIFF
--- a/device-type/overlay-car/frameworks/base/core/res/res/values/config.xml
+++ b/device-type/overlay-car/frameworks/base/core/res/res/values/config.xml
@@ -3,5 +3,6 @@
     <bool name="config_supportsMultiWindow">true</bool>
     <!-- Don't support split screen multiwindow -->
     <bool name="config_supportsSplitScreenMultiWindow">false</bool>
-
+    <!-- Enable AppWidgetService even the FEATURE_APP_WIDGETS is disable -->
+    <bool name="config_enableAppWidgetService">true</bool>
 </resources>


### PR DESCRIPTION
After the FEATURE_APP_WIDGETS is disable, it will cause some applications
crashed when use the AppWidget. Such as play music, calendar, email.

Change-Id: I12ac972bb87c583ef508442ae0b17f2e3db59a7b
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-75541
Signed-off-by: Lei,RayX <rayx.lei@intel.com>
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>