### PR TITLE
bluetooth: Fix for bluetooth app crash

### DIFF
--- a/bluetooth/overlay-tablet/packages/apps/Bluetooth/res/values/config.xml
+++ b/bluetooth/overlay-tablet/packages/apps/Bluetooth/res/values/config.xml
@@ -14,7 +14,6 @@
 -->
 <resources>
     <bool name="enable_phone_policy">true</bool>
-    <bool name="profile_supported_a2dp">false</bool>
     <bool name="profile_supported_hdp">true</bool>
     <bool name="profile_supported_hs_hfp">true</bool>
     <bool name="profile_supported_hid_host">true</bool>
@@ -25,6 +24,5 @@
     <bool name="pbap_include_photos_in_vcard">true</bool>
     <bool name="pbap_use_profile_for_owner_vcard">true</bool>
     <bool name="profile_supported_map">true</bool>
-    <bool name="profile_supported_avrcp_target">false</bool>
     <bool name="profile_supported_hid_device">true</bool>
 </resources>


### PR DESCRIPTION
A2DP and AVRCP profile are disabled resulting in bluetooth
app crash.

As A2DP and AVRCP profile is supported, enable the profiles.

Tracked-On: OAM-75947
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>