### PR TITLE
Enable input events for HDMI plug/unplug

### DIFF
--- a/audio/overlay-car-legacy/frameworks/base/core/res/res/values/config.xml
+++ b/audio/overlay-car-legacy/frameworks/base/core/res/res/values/config.xml
@@ -10,4 +10,5 @@
     <bool name="config_useFixedVolume">false</bool>
     <!-- Enable AppWidgetService even the FEATURE_APP_WIDGETS is disable -->
     <bool name="config_enableAppWidgetService">true</bool>
+    <bool name="config_useDevInputEventForAudioJack">true</bool>
 </resources>


### PR DESCRIPTION
Enable input events for HDMI plug/unplug

Enable input events for HDMI plug/unplug

Tracked-On: OAM-84728
Signed-off-by: M, Kumar K <kumar.k.m@intel.com>