### PR TITLE
Fix no split screen feature issue in Tablet

### DIFF
--- a/audio/overlay-car-legacy/frameworks/base/core/res/res/values/config.xml
+++ b/audio/overlay-car-legacy/frameworks/base/core/res/res/values/config.xml
@@ -1,14 +1,6 @@
 <resources>
-    <!-- Required to enable activity on secondary display -->
-    <bool name="config_supportsMultiWindow">true</bool>
-    <!-- Don't support split screen multiwindow -->
-    <bool name="config_supportsSplitScreenMultiWindow">false</bool>
-    <!-- Set device as "voice capable", it support make a call through BT -->
-    <bool name="config_voice_capable">false</bool>
     <!-- Flag indicating that the media framework should not allow changes or mute on any
          stream or master volumes. -->
     <bool name="config_useFixedVolume">false</bool>
-    <!-- Enable AppWidgetService even the FEATURE_APP_WIDGETS is disable -->
-    <bool name="config_enableAppWidgetService">true</bool>
     <bool name="config_useDevInputEventForAudioJack">true</bool>
 </resources>


### PR DESCRIPTION
71e75cd overlay config_useFixedVolume for fix audio issue, but it
copy some others config too that were used by others features, it
will cause some bug in different product.
Remove these duplicated overlay configs to fix no split screen feature
issue in Tablet device.

Tracked-On: OAM-86816