### PR TITLE
Bluetooth and WLAN mixin changes to adopt aaf

### DIFF
--- a/bluetooth/car/bdroid_buildcfg.h
+++ b/bluetooth/car/bdroid_buildcfg.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _BDROID_BUILDCFG_H
+#define _BDROID_BUILDCFG_H
+
+#define BTM_DEF_LOCAL_NAME "{{target}}"
+
+#define BTA_AV_SINK_INCLUDED TRUE
+#define BLE_VND_INCLUDED FALSE
+#define BTM_SSR_INCLUDED FALSE
+#endif

--- a/bluetooth/overlay-car/frameworks/base/core/res/res/values/config.xml
+++ b/bluetooth/overlay-car/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds.  Do not translate.
+
+     NOTE: The naming convention is "config_camelCaseValue". Some legacy
+     entries do not follow the convention, but all new entries should. -->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- List of restricted usb devices to exclude. Items should be added in the format
+         vendorId:produtId.
+    -->
+    <string-array name="config_usbDeviceBlacklist" translatable="false">
+        <item>"8087:0a2b"</item>
+        <item>"8087:0aa7"</item>
+    </string-array>
+
+</resources>

--- a/bluetooth/overlay-tablet/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
+++ b/bluetooth/overlay-tablet/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/**
+ * Copyright (c) 2009, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<resources>
+    <bool name="def_bluetooth_on">false</bool>
+</resources>

--- a/bluetooth/overlay-tablet/packages/apps/Bluetooth/res/values/config.xml
+++ b/bluetooth/overlay-tablet/packages/apps/Bluetooth/res/values/config.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2009-2012 Broadcom Corporation
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<resources>
+    <bool name="enable_phone_policy">true</bool>
+    <bool name="profile_supported_hdp">true</bool>
+    <bool name="profile_supported_hs_hfp">true</bool>
+    <bool name="profile_supported_hid_host">true</bool>
+    <bool name="profile_supported_opp">true</bool>
+    <bool name="profile_supported_pan">true</bool>
+    <bool name="profile_supported_pbap">true</bool>
+    <bool name="profile_supported_gatt">true</bool>
+    <bool name="pbap_include_photos_in_vcard">true</bool>
+    <bool name="pbap_use_profile_for_owner_vcard">true</bool>
+    <bool name="profile_supported_map">true</bool>
+    <bool name="profile_supported_hid_device">true</bool>
+</resources>

--- a/bluetooth/tablet/bdroid_buildcfg.h
+++ b/bluetooth/tablet/bdroid_buildcfg.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _BDROID_BUILDCFG_H
+#define _BDROID_BUILDCFG_H
+
+#define BTM_DEF_LOCAL_NAME "{{target}}"
+
+/* Default class of device
+* {SERVICE_CLASS, MAJOR_CLASS, MINOR_CLASS}
+*
+* SERVICE_CLASS:0x1A (Bit17 -Networking,Bit19 - Capturing,Bit20 -Object Transfer)
+* MAJOR_CLASS:0x01 - COMPUTER
+* MINOR_CLASS:0x1C - TABLET
+*/
+#define BTA_DM_COD {0x1A, 0x01, 0x1C}
+
+#define BLE_VND_INCLUDED FALSE
+#define BTM_SSR_INCLUDED FALSE
+
+#endif

--- a/wlan/p2p_supplicant_overlay.conf
+++ b/wlan/p2p_supplicant_overlay.conf
@@ -1,0 +1,2 @@
+disable_scan_offload=1
+p2p_no_group_iface=1

--- a/wlan/wlan.conf
+++ b/wlan/wlan.conf
@@ -1,0 +1,3 @@
+softdep iwlwifi post: mac80211 iwlmvm
+options mwifiex driver_mode=5 debug_mask=7 disable_auto_ds=1 disconnect_on_suspend=1
+options iwlwifi d0i3_disable=1 power_scheme=1

--- a/wlan/wpa_supplicant_overlay.conf
+++ b/wlan/wpa_supplicant_overlay.conf
@@ -1,2 +1,5 @@
 ctrl_interface=wlan0
-wowlan_triggers=any
+disable_scan_offload=1
+pmf=1
+sched_scan_plans=30:10 300
+p2p_disabled=1


### PR DESCRIPTION
Changes done:
- Add overlays and configuration files needed for
supporting multiple connectivity modules.
- Marvell 8897(bluetooth over usb) and Intel Connectivity modules
are verified with this patch.

Tracked-On: OAM-88286
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>