### PR TITLE
rma: change crypto library

### DIFF
--- a/action-authorization/Android.mk
+++ b/action-authorization/Android.mk
@@ -11,6 +11,6 @@ LOCAL_MODULE := action-authorization
 LOCAL_SRC_FILES := action-authorization.c
 LOCAL_C_INCLUDES := vendor/intel/external/openssl/include/
 LOCAL_CFLAGS := -Wall -Wextra -Werror
-LOCAL_STATIC_LIBRARIES := libcrypto_static2
+LOCAL_STATIC_LIBRARIES := libcrypto
 
 include $(BUILD_HOST_EXECUTABLE)


### PR DESCRIPTION
rma tools should use crypto library of build machine.

Tracked-On: OAM-90438
Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>