### PR TITLE
Bluetooth fix on `device-type: car` builds

### DIFF
--- a/bluetooth/car/bdroid_buildcfg.h
+++ b/bluetooth/car/bdroid_buildcfg.h
@@ -17,7 +17,7 @@
 #ifndef _BDROID_BUILDCFG_H
 #define _BDROID_BUILDCFG_H
 
-#define BTM_DEF_LOCAL_NAME "{{target}}"
+#define BTM_DEF_LOCAL_NAME "celadon"
 
 #define BTA_AV_SINK_INCLUDED TRUE
 #define BLE_VND_INCLUDED FALSE

--- a/bluetooth/overlay-car/frameworks/base/core/res/res/values/config.xml
+++ b/bluetooth/overlay-car/frameworks/base/core/res/res/values/config.xml
@@ -30,6 +30,7 @@
     <string-array name="config_usbDeviceBlacklist" translatable="false">
         <item>"8087:0a2b"</item>
         <item>"8087:0aa7"</item>
+        <item>"8087:0aaa"</item>
     </string-array>
 
 </resources>


### PR DESCRIPTION
This change makes Bluetooth work on NUC8i5BEH2 devices (among others) configured with `device-type: car`.

As a bonus, I noticed bluedroid's default name doesn't get expanded by mixin, so I just replaced it with a normal name.