### PR TITLE
Remove p2p_disabled from wpa_supplicant_overlay.conf

### DIFF
--- a/wlan/wpa_supplicant_overlay.conf
+++ b/wlan/wpa_supplicant_overlay.conf
@@ -2,4 +2,3 @@ ctrl_interface=wlan0
 disable_scan_offload=1
 pmf=1
 sched_scan_plans=30:10 300
-p2p_disabled=1


### PR DESCRIPTION
Wi-Fi direct not working as p2p_disabled in conf file.

Tracked-On: OAM-91329
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>