### PR TITLE
Set bluetooth device name

### DIFF
--- a/bluetooth/tablet/bdroid_buildcfg.h
+++ b/bluetooth/tablet/bdroid_buildcfg.h
@@ -17,7 +17,7 @@
 #ifndef _BDROID_BUILDCFG_H
 #define _BDROID_BUILDCFG_H
 
-#define BTM_DEF_LOCAL_NAME "{{target}}"
+#define BTM_DEF_LOCAL_NAME "celadon"
 
 /* Default class of device
 * {SERVICE_CLASS, MAJOR_CLASS, MINOR_CLASS}


### PR DESCRIPTION
Bluetooth device name is shown as {{target}} in UI.

Fix the issue by setting bluetooth device name properly instead
of {{target}}.

Tracked-On: OAM-94329
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>