### PR TITLE
Set driver param use_p2p_group_interface=1

### DIFF
--- a/wlan/iwlwifi/wpa_supplicant_overlay.conf
+++ b/wlan/iwlwifi/wpa_supplicant_overlay.conf
@@ -3,4 +3,4 @@ disable_scan_offload=1
 wowlan_triggers=any
 pmf=1
 sched_scan_plans=30:10 300
-
+driver_param=use_p2p_group_interface=1


### PR DESCRIPTION
As supplicant rc entry from external/wpa_supplicant_8 is going
to be used, instead of providing param as parameter to service
start, use_p2p_group_interface is set in wpa_supplicant conf file.

Tracked-On: OAM-95969
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>