### PR TITLE
Thermal Fine tuning for TGL NUC BM

### DIFF
--- a/thermal/thermal-daemon/thermal-conf.xml
+++ b/thermal/thermal-daemon/thermal-conf.xml
@@ -123,7 +123,7 @@
 				<TripPoints>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>85000</Temperature>
+						<Temperature>70000</Temperature>
 						<Type>Passive</Type>
 						<CoolingDevice>
 							<Type>rapl_limit_1</Type>
@@ -131,7 +131,7 @@
 					</TripPoint>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>95000</Temperature>
+						<Temperature>85000</Temperature>
 						<Type>Passive</Type>
 						<CoolingDevice>
 							<Type>rapl_limit_2</Type>
@@ -144,7 +144,7 @@
 				<TripPoints>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>99000</Temperature>
+						<Temperature>100000</Temperature>
 						<Type>Critical</Type>
 					</TripPoint>
 				</TripPoints>


### PR DESCRIPTION
Thermal Fine tuning for TGL NUC BM.

Finetuned thermal trip parameters to avoid unexpected 
shutdown for TGL BM Device.

Tracked-On: OAM-99878
Signed-off-by: vilasrk <vilas.r.k@intel.com>