### PR TITLE
Thermal Fine tuning for TGL NUC BM

### DIFF
--- a/thermal/thermal-daemon/thermal-conf.xml
+++ b/thermal/thermal-daemon/thermal-conf.xml
@@ -11,7 +11,7 @@
 				<TripPoints>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>85000</Temperature>
+						<Temperature>42000</Temperature>
 						<Type>Passive</Type>
 						<CoolingDevice>
 							<Type>rapl_limit_1</Type>
@@ -19,7 +19,7 @@
 					</TripPoint>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>95000</Temperature>
+						<Temperature>58000</Temperature>
 						<Type>Passive</Type>
 						<CoolingDevice>
 							<Type>rapl_limit_2</Type>
@@ -32,7 +32,7 @@
 				<TripPoints>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>99000</Temperature>
+						<Temperature>100000</Temperature>
 						<Type>Critical</Type>
 					</TripPoint>
 				</TripPoints>
@@ -123,7 +123,7 @@
 				<TripPoints>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>70000</Temperature>
+						<Temperature>42000</Temperature>
 						<Type>Passive</Type>
 						<CoolingDevice>
 							<Type>rapl_limit_1</Type>
@@ -131,7 +131,7 @@
 					</TripPoint>
 					<TripPoint>
 						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>85000</Temperature>
+						<Temperature>58000</Temperature>
 						<Type>Passive</Type>
 						<CoolingDevice>
 							<Type>rapl_limit_2</Type>


### PR DESCRIPTION
Finetuned thermal trip parameters to avoid unexpected
shutdown for TGL NUC Qi7 and TGL NUC i7 devices.

Tracked-On: OAM-100282
Signed-off-by: vilasrk <vilas.r.k@intel.com>