### PR TITLE
Update Tethering package name in rro_overlays

### DIFF
--- a/rro_overlays/TetheringOverlay/AndroidManifest.xml
+++ b/rro_overlays/TetheringOverlay/AndroidManifest.xml
@@ -4,7 +4,7 @@
     android:versionName="1.0">
     <application android:hasCode="false" />
     <overlay
-      android:targetPackage="com.google.android.networkstack.tethering"
+      android:targetPackage="com.android.networkstack.tethering"
       android:targetName="TetheringConfig"
       android:isStatic="true"
       android:priority="0"/>


### PR DESCRIPTION
Changes made to update the correct tethering package name
that started used in Android S onwards,

"com.android.networkstack.tethering"

Traked-On: OAM-102707
Signed-off-by: Bharat B Panda <bharat.b.panda@intel.com>