### PR TITLE
Configure rro overlay for connectivity to address CTS issue

### DIFF
--- a/rro_overlays/ServiceConnectivityResourcesOverlay/Android.bp
+++ b/rro_overlays/ServiceConnectivityResourcesOverlay/Android.bp
@@ -1,0 +1,23 @@
+//
+// Copyright (C) 2022 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+runtime_resource_overlay {
+    name: "ServiceConnectivityResourcesConfigOverlay",
+    sdk_version: "current",
+    resource_dirs: ["res"],
+    product_specific: true,
+}
+

--- a/rro_overlays/ServiceConnectivityResourcesOverlay/AndroidManifest.xml
+++ b/rro_overlays/ServiceConnectivityResourcesOverlay/AndroidManifest.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<!-- Manifest for connectivity resources APK -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.android.connectivity.resources.celadon"
+          android:versionCode="1"
+          android:versionName="1.0">
+    <application android:hasCode="false" />
+     <overlay
+      android:targetPackage="com.android.connectivity.resources"
+      android:targetName="ServiceConnectivityResourcesConfig"
+      android:isStatic="true"
+      android:priority="0"/>    
+</manifest>

--- a/rro_overlays/ServiceConnectivityResourcesOverlay/res/values/config.xml
+++ b/rro_overlays/ServiceConnectivityResourcesOverlay/res/values/config.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2022 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+
+    <!-- Default supported concurrent socket keepalive slots per transport type, used by
+         ConnectivityManager.createSocketKeepalive() for calculating the number of keepalive
+         offload slots that should be reserved for privileged access. This string array should be
+         overridden by the device to present the capability of creating socket keepalives. -->
+    <!-- An Array of "[NetworkCapabilities.TRANSPORT_*],[supported keepalives] -->
+    <string-array translatable="false" name="config_networkSupportedKeepaliveCount">
+    </string-array>
+
+</resources>


### PR DESCRIPTION
Keepalive packet offloading is enabled by default. CTS test cases
are failing as the keepalive offloading event is not received.

As Keepalive is not supported, configure the rro overlay for
ServiceConnectivityResource to disable the
networkSupportedKeepaliveCount to fix the Cts Net TC module issue.

Tracked-On: OAM-104109
Signed-off-by: gollarx <ratnakumarix.golla@intel.com>