### PR TITLE
Clean up the mali folders in graphics

### DIFF
--- a/graphics/mali-vp/egl.cfg
+++ b/graphics/mali-vp/egl.cfg
@@ -1,1 +1,0 @@
-0 0 android

--- a/graphics/mali/egl.cfg
+++ b/graphics/mali/egl.cfg
@@ -1,2 +1,0 @@
-0 0 android
-0 1 mali


### PR DESCRIPTION
The mali folders are no longer used anymore, clean up them and keep the graphics folder for future possible use.

Tracked-On: OAM-104671
Signed-off-by: Lu Yang A <yang.a.lu@intel.com>