### PR TITLE
Clean up media

### DIFF
--- a/media/wrs_omxil_components.list
+++ b/media/wrs_omxil_components.list
@@ -1,4 +1,0 @@
-libOMXVideoDecoderMPEG4.so
-libOMXVideoDecoderH263.so
-libOMXVideoEncoderMPEG4.so
-libOMXVideoEncoderH263.so


### PR DESCRIPTION
Only OMX lib is included in the media folder.
OMX is not used any more

Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>