### PR TITLE
Fix boot.img creation failue due to size limit

### DIFF
--- a/firmware.mk
+++ b/firmware.mk
@@ -28,15 +28,24 @@ else
 
 ## List of complete Firmware folders to be copied
 LOCAL_FIRMWARE_DIR := \
-    intel \
-    i915
+    intel
 
 ## List of matching patterns of Firmware bins to be copied
 LOCAL_FIRMWARE_PATTERN := \
     iwlwifi
 
+LOCAL_FIRMWARE_PATTERN_IN_DIR := \
+    i915/kbl \
+    i915/bxt \
+    i915/cml \
+    i915/ehl \
+    i915/tgl \
+    i915/adl \
+    i915/dg2
+
 LOCAL_FIRMWARE_SRC += $(foreach f,$(LOCAL_FIRMWARE_PATTERN),$(shell cd $(FIRMWARES_DIR) && find . -iname "*$(f)*" -type f,l ))
 LOCAL_FIRMWARE_SRC += $(foreach f,$(LOCAL_FIRMWARE_DIR),$(shell cd $(FIRMWARES_DIR) && find $(f) -type f,l) )
+LOCAL_FIRMWARE_SRC += $(foreach f,$(LOCAL_FIRMWARE_PATTERN_IN_DIR),$(shell cd $(FIRMWARES_DIR) && find $(shell dirname $(f)) -iname "$(shell basename $(f))*" -type f,l))
 
 PRODUCT_COPY_FILES := \
     $(foreach f,$(LOCAL_FIRMWARE_SRC),$(FIRMWARES_DIR)/$(f):$(TARGET_COPY_OUT_VENDOR)/firmware/$(f))


### PR DESCRIPTION
Creation of boot.img fails due to size exceeding maximum size limit of 40MB.

When all guc and huc files are included, boot.img size is exceeding the max size of 40MB.

Copy GuC and HuC files of supported platforms to avoid boot image size exceeding set maximum size limit.

Change-Id: Ice350188cb7acad12f1c0edcf05e59c3c53c6db6
Tracked-On: OAM-104960
Signed-off-by: Sundar Gnanasekaran <sundar.gnanasekaran@intel.com>
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>