### PR TITLE
Remove the unnecessary component list

### DIFF
--- a/media/wrs_omxil_components.list
+++ b/media/wrs_omxil_components.list
@@ -1,4 +1,0 @@
-libOMXVideoDecoderMPEG4.so
-libOMXVideoDecoderH263.so
-libOMXVideoEncoderMPEG4.so
-libOMXVideoEncoderH263.so


### PR DESCRIPTION
OMX is not used on celadon anylonger.

Tracked-On: OAM-110735