### PR TITLE
Disable thermal daemon on A0 Sample

### DIFF
--- a/thermal/thermal-daemon/thermal-conf.xml
+++ b/thermal/thermal-daemon/thermal-conf.xml
@@ -2,62 +2,6 @@
 <!-- BEGIN -->
 <ThermalConfiguration>
 	<Platform>
-		<Name> RPL i5-1350PRE </Name>
-		<ProductName>RPLP LP5 (CPU:RaptorLake)</ProductName>
-		<Preference>QUIET</Preference>
-		<ThermalZones>
-			<ThermalZone>
-				<Type>cpu_passive</Type>
-				<TripPoints>
-					<TripPoint>
-						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>85000</Temperature>
-						<Type>Passive</Type>
-						<CoolingDevice>
-							<Type>rapl_limit_1</Type>
-						</CoolingDevice>
-					</TripPoint>
-					<TripPoint>
-						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>95000</Temperature>
-						<Type>Passive</Type>
-						<CoolingDevice>
-							<Type>rapl_limit_2</Type>
-						</CoolingDevice>
-					</TripPoint>
-				</TripPoints>
-			</ThermalZone>
-			<ThermalZone>
-				<Type>cpu_critical</Type>
-				<TripPoints>
-					<TripPoint>
-						<SensorType>x86_pkg_temp</SensorType>
-						<Temperature>101000</Temperature>
-						<Type>Critical</Type>
-					</TripPoint>
-				</TripPoints>
-			</ThermalZone>
-		</ThermalZones>
-	        <CoolingDevices>
-                        <CoolingDevice>
-                                <Type>rapl_limit_1</Type>
-				<Path>/sys/class/powercap/intel-rapl/intel-rapl:0/constraint_0_power_limit_uw</Path>
-                                <MinState>28000000</MinState>
-                                <ReadBack>0</ReadBack>
-                                <MaxState>14000000</MaxState>
-                                <IncDecStep>-200000</IncDecStep>
-                        </CoolingDevice>
-                        <CoolingDevice>
-                                <Type>rapl_limit_2</Type>
-				<Path>/sys/class/powercap/intel-rapl/intel-rapl:0/constraint_0_power_limit_uw</Path>
-                                <MinState>14000000</MinState>
-                                <ReadBack>0</ReadBack>
-                                <MaxState>7000000</MaxState>
-                                <IncDecStep>-200000</IncDecStep>
-                        </CoolingDevice>
-                </CoolingDevices>
-	</Platform>
-	<Platform>
 		<Name> ADL IVI RVP </Name>
 		<ProductName>CIA1-PC 2</ProductName>
 		<Preference>QUIET</Preference>


### PR DESCRIPTION
Remove high temperature throttling to investigate PNP KPI target.