### PR TITLE
Fix Bluetooth joystick connection issue

### DIFF
--- a/bluetooth/overlay-car/packages/apps/Bluetooth/res/values/config.xml
+++ b/bluetooth/overlay-car/packages/apps/Bluetooth/res/values/config.xml
@@ -20,7 +20,7 @@
     <bool name="profile_supported_avrcp_controller">true</bool>
     <bool name="profile_supported_pbapclient">true</bool>
     <bool name="profile_supported_opp">true</bool>
-    <bool name="profile_supported_hid_host">false</bool>
+    <bool name="profile_supported_hid_host">true</bool>
     <bool name="profile_supported_mapmce">true</bool>
     <!-- For enabling the hfp client connection service -->
     <bool name="hfp_client_connection_service_enabled">true</bool>


### PR DESCRIPTION
Enable HID host profile for Bluetooth car use cases, which enables the Bluetooth HID joystick, mouse, keyboard connection for ivi.

Validated the BT Sony joystick connection and its able to control the ivi UI.

Tracked-On: OAM-112821
Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
