### PR TITLE
Fix kernel panic when booted in SRIOV config

### DIFF
--- a/host_scripts/setup_host.sh
+++ b/host_scripts/setup_host.sh
@@ -204,9 +204,9 @@ function ubu_enable_host_sriov(){
 }
 
 function ubu_update_fw(){
-    FW_REL="linux-firmware-20231111"
+    FW_REL="linux-firmware-20230919"
 
-    [ ! -f $CIV_WORK_DIR/$FW_REL.tar.xz ] && wget "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-20231111.tar.gz" -P $CIV_WORK_DIR
+    [ ! -f $CIV_WORK_DIR/$FW_REL.tar.xz ] && wget "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-20230919.tar.gz" -P $CIV_WORK_DIR
 
     [ -d $CIV_WORK_DIR/$FW_REL ] && rm -rf $CIV_WORK_DIR/$FW_REL
     tar -xf $CIV_WORK_DIR/$FW_REL.tar.gz


### PR DESCRIPTION
As kernel panic is  seen on SRIOV boot, rolling back firmware package to version linux-firmware-20230919 until the latest kernel and firmware combo is verified successfully.

Tests done:
- setup_host runs and firmwares are updated properly on host side.
- Graphics, Wi-Fi and bluetooth firmwares are getting loaded properly on host side.

Tracked-On: OAM-114193