### PR TITLE
Change to performance mode as customer's requirement

### DIFF
--- a/thermal/thermal-daemon/thermal-conf.xml
+++ b/thermal/thermal-daemon/thermal-conf.xml
@@ -2,6 +2,40 @@
 <!-- BEGIN -->
 <ThermalConfiguration>
 	<Platform>
+		<Name> RPL i5-1350PRE </Name>
+		<ProductName>RPLP LP5 (CPU:RaptorLake)</ProductName>
+		<Preference>PERFORMANCE</Preference>
+		<ThermalZones>
+			<ThermalZone>
+				<Type>cpu_critical</Type>
+				<TripPoints>
+					<TripPoint>
+						<SensorType>x86_pkg_temp</SensorType>
+						<Temperature>101000</Temperature>
+						<Type>Critical</Type>
+					</TripPoint>
+				</TripPoints>
+			</ThermalZone>
+		</ThermalZones>
+	</Platform>
+	<Platform>
+		<Name> ADL IVI RVP </Name>
+		<ProductName>CIA1-PC 2</ProductName>
+		<Preference>PERFORMANCE</Preference>
+		<ThermalZones>
+			<ThermalZone>
+				<Type>cpu_critical</Type>
+				<TripPoints>
+					<TripPoint>
+						<SensorType>x86_pkg_temp</SensorType>
+						<Temperature>101000</Temperature>
+						<Type>Critical</Type>
+					</TripPoint>
+				</TripPoints>
+			</ThermalZone>
+		</ThermalZones>
+	</Platform>
+	<Platform>
 		<Name> TGL NUC Qi7 </Name>
 		<ProductName>NUC11PAQi7</ProductName>
 		<Preference>QUIET</Preference>


### PR DESCRIPTION
The customer doesn't want to reduce SoC frequency at high temperature, they want to keep the full frequency and use performance mode.
So we change to performance mode, remove the RAPL related passive policy which reduces power limit when CPU package temperature is high.

Tracked-On: OAM-115355