### PR TITLE
Update kernel command line parameters for sriov

### DIFF
--- a/host_scripts/setup_host.sh
+++ b/host_scripts/setup_host.sh
@@ -182,12 +182,12 @@ function ubu_enable_host_gvt(){
 }
 
 function ubu_enable_host_sriov(){
-   if [[ ! `cat /etc/default/grub` =~ "i915.enable_guc=0x7" ]]; then
+   if [[ ! `cat /etc/default/grub` =~ "i915.max_vfs" ]]; then
         read -p "Do you want to update the grub entry in '/etc/default/grub' for enabling SRIOV? [Y/n]" res
         if [ x$res = xn ]; then
             return
         fi
-	sed -i "s/GRUB_CMDLINE_LINUX=\"/GRUB_CMDLINE_LINUX=\"i915.enable_guc=0x7 udmabuf.list_limit=8192  /g" /etc/default/grub
+	sed -i "s/GRUB_CMDLINE_LINUX=\"/GRUB_CMDLINE_LINUX=\"i915.max_vfs=4 udmabuf.list_limit=8192  /g" /etc/default/grub
         update-grub
 
         echo -e "\nkvmgt\nvfio-iommu-type1\nvfio-mdev\n" >> /etc/initramfs-tools/modules


### PR DESCRIPTION
With latest kernels, android is not booting in SR-IOV config.

With latest kernel, GuC submission and HuC authentication is determined by the driver itself. So, enable_guc module parameter should not be overrided. Also, max_vfs parameter needs to be set for spawning upto max_vfs number of virtual functions.

Update the kernel command line parameter for Android to boot with SR-IOV config.

Tests done:
- Android boot
- adb reboot

Tracked-On: OAM-114191