### PR TITLE
Update BT FW for AX211 MA sample

### DIFF
--- a/host_scripts/setup_host.sh
+++ b/host_scripts/setup_host.sh
@@ -430,12 +430,13 @@ function ubu_update_bt_fw() {
         cd linux-firmware
         # Checkout to specific commit as guest also uses this version. Latest
         # is not taken as firmware update process in the guest is manual
-        git checkout b377ccf4f1ba7416b08c7f1170c3e28a460ac29e
+        git checkout d3cc8b9b304af1671d47726f77177c28067d5c04
         cd -
         sudo cp linux-firmware/intel/ibt-19-0-4* /lib/firmware/intel
         sudo cp linux-firmware/intel/ibt-18-16-1* /lib/firmware/intel
         sudo cp linux-firmware/intel/ibt-0040-0041* /lib/firmware/intel
         sudo cp linux-firmware/intel/ibt-0040-4150* /lib/firmware/intel
+        sudo cp linux-firmware/intel/ibt-0180-0041* /lib/firmware/intel
         ln -sf /lib/firmware/intel/ibt-19-0-4.sfi /lib/firmware/intel/ibt-19-16-0.sfi
         ln -sf /lib/firmware/intel/ibt-19-0-4.ddc /lib/firmware/intel/ibt-19-16-0.ddc
         hcitool cmd 3f 01 01 01 00 00 00 00 00 > /dev/null 2>&1 &


### PR DESCRIPTION
The commit id for BT firmware files are old and does not contain the fw files for AX211 MA sample.

Upgrade the BT firmware to latest commit id, which includes ibt-0180-0041 fw files. And push the same to host so that setup host will succeed.

Tests done:
1. Run setup host script
2. Reboot host
3. Check host BT is up
4. Flash binary and boot CiV14 with GVT-d
5. Boot check CiV14
6. Verify CiV14 BT on/off

Tracked-On: OAM-117261