### PR TITLE
Configure rro overlay for overriding config_occupant_display_mapping

### DIFF
--- a/rro_overlays/CarServiceOverlay/Android.bp
+++ b/rro_overlays/CarServiceOverlay/Android.bp
@@ -1,0 +1,26 @@
+// Copyright (C) 2022 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+
+
+runtime_resource_overlay {
+    name: "CarServiceOverlayIntel",
+    resource_dirs: ["res"],
+    manifest: "AndroidManifest.xml",
+    sdk_version: "current",
+    device_specific: true
+}
+

--- a/rro_overlays/CarServiceOverlay/AndroidManifest.xml
+++ b/rro_overlays/CarServiceOverlay/AndroidManifest.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2022 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.android.car.resources.intel.rro">
+    <application android:hasCode="false"/>
+    <overlay android:priority="1001"
+             android:targetPackage="com.android.car.updatable"
+	     android:targetName="CarServiceCustomization"
+	     android:resourcesMap="@xml/overlays"
+             android:isStatic="true" />
+</manifest>
+

--- a/rro_overlays/CarServiceOverlay/res/values/config.xml
+++ b/rro_overlays/CarServiceOverlay/res/values/config.xml
@@ -1,0 +1,5 @@
+<resources>
+ <string-array translatable="false" name="config_occupant_display_mapping">
+      <item>displayPort=0,displayType=MAIN,occupantZoneId=0,inputTypes=TOUCH_SCREEN|DPAD_KEYS|NAVIGATE_KEYS|ROTARY_NAVIGATION</item>
+    </string-array>
+</resources>

--- a/rro_overlays/CarServiceOverlay/res/xml/overlays.xml
+++ b/rro_overlays/CarServiceOverlay/res/xml/overlays.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2022 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<overlay>
+    <item target="array/config_occupant_display_mapping" value="@array/config_occupant_display_mapping" />
+</overlay>
+


### PR DESCRIPTION
    Add CarServiceOverlay rro

    Test: Flash GSI image, and dumpsys car_service --services CarOccupantZoneService

    Tracked-On: OAM-121009

    Signed-off-by: Hongcheng Xie <hongcheng.xie@intel.com> 
   Signed-off-by: Cheng, Ninghuix <ninghuix.chen@intel.com> 