### PR TITLE
fix wifip2p concurrencyTest failure in CTS test

### DIFF
--- a/wlan/iwlwifi/p2p_supplicant_overlay.conf
+++ b/wlan/iwlwifi/p2p_supplicant_overlay.conf
@@ -1,2 +1,2 @@
 disable_scan_offload=1
-p2p_no_group_iface=1
+p2p_no_group_iface=0


### PR DESCRIPTION
Currently wifi p2p group shares network interface with primary interface used by normal STA wifi function since p2p_no_group_iface is set to 1. When wpa_supplicant set P2P mode on primary interface, it will first shut down the interface then set P2P mode and turn it up at last. wifip2pservice would capture the shut down event and stop p2p setup, then the concurrency test will be failed.

Now set p2p_no_group_iface to 0 and then p2p group will use a different network interface compared to primary interface used by normal STA wifi function, so that wpa_supplicant will not do shutdown-up operation.

Tracked-On: OAM-119784