### PR TITLE
Restore some sock config to default setting in Android

### DIFF
--- a/wlan/overlay-disable_keepalive_offload/frameworks/base/core/res/res/values/config.xml
+++ b/wlan/overlay-disable_keepalive_offload/frameworks/base/core/res/res/values/config.xml
@@ -26,8 +26,8 @@
     </string-array>
 
     <!-- Reserved privileged keepalive slots per transport. -->
-    <integer translatable="false" name="config_reservedPrivilegedKeepaliveSlots">0</integer>
+    <integer translatable="false" name="config_reservedPrivilegedKeepaliveSlots">2</integer>
 
     <!-- Allowed unprivileged keepalive slots per uid. -->
-    <integer translatable="false" name="config_allowedUnprivilegedKeepalivePerUid">0</integer>
+    <integer translatable="false" name="config_allowedUnprivilegedKeepalivePerUid">2</integer>
 </resources>


### PR DESCRIPTION
The default config_reservedPrivilegedKeepaliveSlots and config_allowedUnprivilegedKeepalivePerUid are 2 in framework. And these two items were set to 0 to pass CTS test in 2019. Now restore them to 2 and validated the failed cases in orignal bug : 86930. All pass.

Tracked-On : OAM-122137