### PR TITLE
Adding SMS application to default

### DIFF
--- a/device-type/overlay-car/frameworks/base/core/res/res/values/config.xml
+++ b/device-type/overlay-car/frameworks/base/core/res/res/values/config.xml
@@ -13,5 +13,7 @@
     <!-- Disables the GnssTimeUpdate service. This is a switch for enabling Gnss time based
 	 suggestions to TimeDetector service. -->
     <bool name="config_enableGnssTimeUpdateService">false</bool>
+    <!-- The name of the package that will hold the SMS role by default. -->
+    <string name="config_defaultSms" translatable="false">com.android.car.messenger</string>
 </resources>
 


### PR DESCRIPTION
Car-messenger app is not syncing the sms/mms
from BT connected reference phone. Making
default messaging application as car-messenger
in overlay-car config helps to sync the
sms/mms successfully

Test: MessageAccessProfile
1. Connect bluetooth with any mobile device.
2. Give all the permissions for all that are required.
3. Check messages are able to sync in message application.

Tracked-On: OAM-119719