### PR TITLE
Fix vendor.img creation failing with latest build_image script

### DIFF
--- a/firmware.mk
+++ b/firmware.mk
@@ -44,7 +44,7 @@ LOCAL_FIRMWARE_PATTERN_IN_DIR := \
     i915/dg2 \
     i915/mtl
 
-LOCAL_FIRMWARE_SRC += $(foreach f,$(LOCAL_FIRMWARE_PATTERN),$(shell cd $(FIRMWARES_DIR) && find . -iname "*$(f)*" -type f,l ))
+LOCAL_FIRMWARE_SRC += $(foreach f,$(LOCAL_FIRMWARE_PATTERN),$(shell cd $(FIRMWARES_DIR) && find *$(f)* -type f,l ))
 LOCAL_FIRMWARE_SRC += $(foreach f,$(LOCAL_FIRMWARE_DIR),$(shell cd $(FIRMWARES_DIR) && find $(f) -type f,l) )
 LOCAL_FIRMWARE_SRC += $(foreach f,$(LOCAL_FIRMWARE_PATTERN_IN_DIR),$(shell cd $(FIRMWARES_DIR) && find $(shell dirname $(f)) -iname "$(shell basename $(f))*" -type f,l))
 


### PR DESCRIPTION
Latest build_image script used to build vendor.img expects the file paths in the format folder_path/file_name whereasiwlwifi firmware copy script provides the path firmware/./iwlwifi* resulting in build_image failing with firmware/./iwlwifi-100-5.ucode: not normalized.

Modified the find option to fix the path issue.

Tests done:
- Android boot with GVT-d and BM
- Wi-Fi on/off/scan/connect/disconnect
- adb reboot

Tracked-0n: OAM-123050