### PR TITLE
Fix BT HFP call can not reject call issue

### DIFF
--- a/device-type/overlay-car/frameworks/base/core/res/res/values/config.xml
+++ b/device-type/overlay-car/frameworks/base/core/res/res/values/config.xml
@@ -15,5 +15,6 @@
     <bool name="config_enableGnssTimeUpdateService">false</bool>
     <!-- The name of the package that will hold the SMS role by default. -->
     <string name="config_defaultSms" translatable="false">com.android.car.messenger</string>
+    <string name="config_defaultDialer" translatable="false">com.android.car.dialer</string>
 </resources>
 


### PR DESCRIPTION
when a BT HFP call comming,
There is no UI for answering the incoming calls on the IVI device. This patch can fix this issue,

Tests:
it can reject BT HFP call now.

Tracked-On: OAM-123273