### PR TITLE
Make max connected audio a2dp device as one

### DIFF
--- a/bluetooth/overlay-car/packages/modules/Bluetooth/android/app/res/values/config.xml
+++ b/bluetooth/overlay-car/packages/modules/Bluetooth/android/app/res/values/config.xml
@@ -17,4 +17,7 @@
 <resources>
     <!-- If true, device requests audio focus and start avrcp updates on source start or play -->
     <bool name="a2dp_sink_automatically_request_audio_focus">true</bool>
+
+    <!-- Max number of connected audio devices supported by Bluetooth stack -->
+    <integer name="config_bluetooth_max_connected_audio_devices">1</integer>
 </resources>


### PR DESCRIPTION
By default five audio a2dp devices can be connected in AOSP bt-stack, but we support only a2dp streaming at a time. This is causing ambiguity when connect 2nd pixel, the media profile is enabled for both 1st and 2nd pixel, causing ambiguity among user.

Set the maximum connected audio a2dp device as one, which resolves the ambiguity and when connect 2nd pixel device.

Tests-done:
1. Flash BM
2. Connect Pixel1
3. Pixel1 media profile should be connected
4. Connect Pixel2
5. Pixel2 media profile should not be connected, it should be in disconnected state

Tracked-On: OAM-123265