### PR TITLE
Creating overlay for Config Nl80211RegChangedEvent

### DIFF
--- a/wlan/overlay-enable_Nl80211RegChangedEvent/packages/modules/service/ServiceWifiResources/res/values/config.xml
+++ b/wlan/overlay-enable_Nl80211RegChangedEvent/packages/modules/service/ServiceWifiResources/res/values/config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+	<!-- Indicates whether or not the WLAN driver supports the NL80211_CMD_REG_CHANGE or
+         NL80211_CMD_WIPHY_REG_CHANGE events which indicate the current country code which is
+         being used by the WLAN driver. If the driver doesn't support these events
+         (configuration is `false`) then the driver must handle the setCountryCode request from
+         HAL as a blocking call. In such a case the country code will be applied
+         immediately after the country code is sent to the driver (if the method returns a
+	success). -->
+
+	<bool translatable="false" name="config_wifiDriverSupportedNl80211RegChangedEvent">true</bool>
+
+</resources>


### PR DESCRIPTION
For wificond to broadcast wifi region we need this config to be enabled

Test done:
1. Flash the image with changes
2. Connect to wifi Network
3. Ran Cts Test cases in both IN/CN location
4. 5GHz ap working and TC also passing

Tracked-On: OAM-124530