### PR TITLE
Enable Desktop Mode by default on celadon

### DIFF
--- a/device-type/overlay-tablet/frameworks/base/core/res/res/values/config.xml
+++ b/device-type/overlay-tablet/frameworks/base/core/res/res/values/config.xml
@@ -1,7 +1,8 @@
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
+    <bool name="config_showNavigationBar" translatable="false">true</bool>
     <!--  Maximum number of supported users -->
-    <integer name="config_multiuserMaximumUsers">8</integer>
+    <integer name="config_multiuserMaximumUsers" translatable="false">8</integer>
     <!--  Whether UI for multi user should be shown -->
     <bool name="config_enableMultiUserUI">true</bool>
     <!-- The device supports freeform window management. Windows have title bars and can be moved


### PR DESCRIPTION
This patch will enable desktop mode by default on caas builds.

Tests Done: Build and boot and check freeform windowing mode

Tracked-On: NA