### PR TITLE
Fixed for Home/ALL_APPS button in AAOS.

### DIFF
--- a/device-type/overlay-car/frameworks/base/core/res/res/values/config.xml
+++ b/device-type/overlay-car/frameworks/base/core/res/res/values/config.xml
@@ -16,5 +16,7 @@
     <!-- The name of the package that will hold the SMS role by default. -->
     <string name="config_defaultSms" translatable="false">com.android.car.messenger</string>
     <string name="config_defaultDialer" translatable="false">com.android.car.dialer</string>
+    <!-- Is the lock-screen disabled for new users by default -->
+    <bool name="config_disableLockscreenByDefault">true</bool>
 </resources>
 

--- a/device-type/overlay-car/frameworks/base/core/res/res/xml/config_user_types.xml
+++ b/device-type/overlay-car/frameworks/base/core/res/res/xml/config_user_types.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2019 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<user-types>
+    <full-type name="android.os.usertype.full.SECONDARY" >
+	<default-restrictions no_sms="false" no_outgoing_calls="false"/>
+    </full-type>
+    <full-type name="android.os.usertype.full.GUEST"
+        max-allowed="3" >
+        <default-restrictions no_factory_reset="true" no_remove_user="true"
+                  no_modify_accounts="true" no_install_apps="true" no_install_unknown_sources="true"
+                  no_uninstall_apps="true"/>
+    </full-type>
+
+    <profile-type name="android.os.usertype.profile.CLONE"
+        enabled='0' >
+    </profile-type>
+</user-types>
+


### PR DESCRIPTION
From second reboot onwards, home and all apps buttons are getiing disabled. If screen lock is set then this issue is not observed. Reason- Screen lock condition was getting true even there was no screen lock.

Setting default disabled screen lock value to true. Also enabling sms & call feature for secondary users.

Tests: Reboot device few times and check. All navigation keys are working.

Tracked-On: OAM-124177