### PR TITLE
Configure KeepAlive for CTS

### DIFF
--- a/wlan/overlay-disable_keepalive_offload/frameworks/base/core/res/res/values/config.xml
+++ b/wlan/overlay-disable_keepalive_offload/frameworks/base/core/res/res/values/config.xml
@@ -26,8 +26,8 @@
     </string-array>
 
     <!-- Reserved privileged keepalive slots per transport. -->
-    <integer translatable="false" name="config_reservedPrivilegedKeepaliveSlots">0</integer>
+    <integer translatable="false" name="config_reservedPrivilegedKeepaliveSlots">2</integer>
 
     <!-- Allowed unprivileged keepalive slots per uid. -->
-    <integer translatable="false" name="config_allowedUnprivilegedKeepalivePerUid">0</integer>
+    <integer translatable="false" name="config_allowedUnprivilegedKeepalivePerUid">2</integer>
 </resources>


### PR DESCRIPTION
Keep alive feature is disabled to resolve below CTS issue in 2019. That time our controller was not supporting this feature.
https://jira.devtools.intel.com/browse/OAM-86930

Now we support keep alive, CTS is expecting keep alive slots. After setting config_reservedPrivilegedKeepaliveSlots, config_allowedUnprivilegedKeepalivePerUid values to 2 Following Cts is passing:
android.net.cts.ConnectivityManagerTest#testSocketKeepaliveUnprivileged

Tests done:
1. Flash BM
2. run cts -m CtsNetTestCases -t android.net.cts.ConnectivityManagerTest
3. All test should pass

Tracked-On: OAM-119906