### PR TITLE
Add .gitignore file for device-type

### DIFF
--- a/device-type/.gitignore
+++ b/device-type/.gitignore
@@ -1,0 +1,17 @@
+# Ignore all files at the current directory level
+/*
+# Allow subdirectories and their contents
+!*/
+# Allow all files within existing subdirectories
+!*/**
+# Ignore any new directories created at the root level
+/*/
+!.gitignore
+!README
+!core_hardware.xml
+!overlay-car
+!overlay-clamshell
+!overlay-handheld
+!overlay-tablet
+!overlay-tablet-lowram
+

--- a/device-type/README
+++ b/device-type/README
@@ -1,0 +1,5 @@
+### Important Notice ###
+
+# Any new file or folder added in device/intel/common/device-type
+# needs to be added to the device/intel/common/device-type/.gitignore
+# file as others are added to be visible for git repo.


### PR DESCRIPTION
This patch will add all files and folders inside device-type folder. This will ignore showing the embargoed projects.

Tests Done: git status

Tracked-On: OAM-126628