### PR TITLE
Enable KeepAlive feature to address CTS issue

### DIFF
--- a/wlan/overlay-disable_keepalive_offload/frameworks/base/core/res/res/values/config.xml
+++ b/wlan/overlay-disable_keepalive_offload/frameworks/base/core/res/res/values/config.xml
@@ -26,8 +26,8 @@
     </string-array>
 
     <!-- Reserved privileged keepalive slots per transport. -->
-    <integer translatable="false" name="config_reservedPrivilegedKeepaliveSlots">0</integer>
+    <integer translatable="false" name="config_reservedPrivilegedKeepaliveSlots">2</integer>
 
     <!-- Allowed unprivileged keepalive slots per uid. -->
-    <integer translatable="false" name="config_allowedUnprivilegedKeepalivePerUid">0</integer>
+    <integer translatable="false" name="config_allowedUnprivilegedKeepalivePerUid">2</integer>
 </resources>


### PR DESCRIPTION
The KeepAlive feature was disabled in OAM-86930.

Now the this feature is supported, mentioned in below jira OAM-119906

After setting below configuration values to 2, enables the feature
 - config_reservedPrivilegedKeepaliveSlots
 - config_allowedUnprivilegedKeepalivePerUid

Tests done:
  - Android boot-up success
  - All testcase are passing run cts -m CtsNetTestCases -t android.net.cts.ConnectivityManagerTest

Tracked-On: OAM-127805