### PR TITLE
[Do Not Merge] Enable volume control for usb audio device

### DIFF
--- a/device-type/overlay-car/frameworks/base/core/res/res/values/config.xml
+++ b/device-type/overlay-car/frameworks/base/core/res/res/values/config.xml
@@ -7,7 +7,7 @@
     <bool name="config_voice_capable">false</bool>
     <!-- Flag indicating that the media framework should not allow changes or mute on any
          stream or master volumes. -->
-    <bool name="config_useFixedVolume">true</bool>
+    <bool name="config_useFixedVolume">false</bool>
     <!-- Enable AppWidgetService even the FEATURE_APP_WIDGETS is disable -->
     <bool name="config_enableAppWidgetService">true</bool>
     <!-- Disables the GnssTimeUpdate service. This is a switch for enabling Gnss time based


### PR DESCRIPTION
The config_useFixedVolume was set to true in 2018 to fix cts bugs. Please check OAM-70225. Now disable it for usb device on PTL

Fixes OAM-130757